### PR TITLE
Fix having to enter multiple correct line numbers after "out of range"

### DIFF
--- a/Snibbets.lbaction/Contents/Scripts/snibbets.rb
+++ b/Snibbets.lbaction/Contents/Scripts/snibbets.rb
@@ -113,7 +113,7 @@ def menu(res,title="Select one")
         break
       else
         $stderr.puts "Out of range"
-        menu(res,title)
+        return menu(res,title)
       end
     end
   rescue Interrupt => e

--- a/snibbets
+++ b/snibbets
@@ -113,7 +113,7 @@ def menu(res,title="Select one")
         break
       else
         $stderr.puts "Out of range"
-        menu(res,title)
+        return menu(res,title)
       end
     end
   rescue Interrupt => e


### PR DESCRIPTION
The result of recursive call to `menu` isn’t returned, so the user goes round the loop again.

So, for instance, if you have three options, enter '4' and get the out of range message, you then have to enter say "3" and then "3" again to make progress.

Returning the result of the recursive call fixes this.